### PR TITLE
0019307: php code not executing in subscribe page header

### DIFF
--- a/frontendheader.php
+++ b/frontendheader.php
@@ -2,7 +2,7 @@
 <meta name="theme-color" content="#2C2C2C"/>
 <link rel="apple-touch-icon" href="./images/phplist-touch-icon.png" />
 <link rel="apple-touch-icon-precomposed" href="./images/phplist-touch-icon.png" />
-<link rel="stylesheet" href="admin/ui/phplist-ui-bootlist/css/style.css?v=<?php echo filemtime(dirname(__FILE__).'/css/style.css'); ?>" />
+<link rel="stylesheet" href="admin/ui/phplist-ui-bootlist/css/style.css" />
 </head>
 
 <body class="fixed invisible">


### PR DESCRIPTION
This commit removed from default subscribe page header, the php code included to avoid browser cache of style.css, because the application is not using frontendheader.php as an include, so php is not executing.

Mantis link: https://mantis.phplist.org/view.php?id=19307