### PR TITLE
fix for andSelf method

### DIFF
--- a/js/phpList3ToBootstrap.js
+++ b/js/phpList3ToBootstrap.js
@@ -205,7 +205,7 @@ $('body.fixed li.list').each(function(){
     $('#progresscount').addClass('text-warning');
     $('#processqueuecontrols a').addClass('btn-xs');
 
-/* COLLAPSIBLE */
+/* COLLAPSIBLE*/
     if ( !$('.accordion').hasClass('panel-group') ){
         $('.accordion').addClass('panel-group').attr({ 'aria-multiselectable':'true', 'id':'accordion','role':'tablist' });
         $('.accordion h3').addClass('panel-title').each(function(){ $(this).next('div').addBack().wrapAll('<div class="panel panel-default"/>'); });


### PR DESCRIPTION
This PR has intention  to fix Coipasa jQuery upgrade issue related with the parent theme-trevelin theme.

I want to make sure that Bootlist has the new upgraded method(.addBack() on line 211).

This is not present here:
https://phplist.staging.phplist.com/lists/admin/ui/phplist-ui-bootlist/js/phpList3ToBootstrap.js