### PR TITLE
Remove unnecessary function calls for page category and subcategory

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -5,40 +5,29 @@ if ($page_title =='userclicks') $page_title = s('Click Statistics'); /* REMOVE A
 /* This array is to add third level to phpList menu, adding orphan items to a menulink */
 
 $GLOBALS['subcat'] = array(
-	'import' => array ('import1','import2','import3','import4','importsimple'),
-	'users' => array('user','userhistory'),
-	'list' => array('members','editlist'),
-	'usermgt' => array('massremove','usercheck','reconcileusers'),
-	'messages' => array('message'),
-	'templates' => array('template'),
-	'system' => array('converttoutf8'),
-	'bouncemgt' => array('bounce','bounces','processbounces','generatebouncerules'),
-	'bouncerules' => array('bouncerule'),
-	'spage' => array('spageedit'),
-	'attributes' => array('editattributes','defaults'),
-	);
-
-
-/* This function is to add third level to phpList menu */
-function pageSubCategory($menulinks = array(), $current) {
-    foreach ($GLOBALS['subcat'] as $subcategory => $subcat_details) {
-        if ( !in_array($current, $menulinks) /* <-first check if is not a menulink */ 
-        	&& in_array($current, $subcat_details) /* then find the menulink in array above */ ) {
-            return $subcategory;
-        }
-    }
-    return '';
-}
-
+    'import' => array ('import1','import2','import3','import4','importsimple'),
+    'users' => array('user','userhistory'),
+    'list' => array('members','editlist'),
+    'usermgt' => array('massremove','usercheck','reconcileusers'),
+    'messages' => array('message'),
+    'templates' => array('template'),
+    'system' => array('converttoutf8'),
+    'bouncemgt' => array('bounce','bounces','processbounces','generatebouncerules'),
+    'bouncerules' => array('bouncerule'),
+    'spage' => array('spageedit'),
+    'attributes' => array('editattributes','defaults'),
+    );
 
 /* replace topmenu() function */
 function _topMenu()
 {
-    if ( !isset($_GET['page'] ) ) { $_GET['page'] = ''; }
-    $current_page = htmlentities($_GET['page']);
     if (empty($_SESSION['logindetails'])) {
         return '';
     }
+
+    if ( !isset($_GET['page'] ) ) { $_GET['page'] = ''; }
+    $current_page = htmlentities($_GET['page']);
+    $currentPageCategory = $_GET['pi'] == '' ? pageCategory($current_page) : '';
 
     if ($_SESSION['logindetails']['superuser']) { // we don't have a system yet to distinguish access to plugins
         if (count($GLOBALS['plugins'])) {
@@ -68,47 +57,50 @@ function _topMenu()
         $thismenu = '';
         $icon = 'glyphicon-plus';
         $icontext = "";
-        $open = '';
+        $open = $category == $currentPageCategory ? ' class="active open"' : '';
         $accmenu = '';
         switch ($category) {
-			case "dashboard" : $icon = "glyphicon-home"; break;
-			case "subscribers" : $icon = "glyphicon-user"; break;
-			case "campaigns" : $icon = "glyphicon-envelope"; break;
-			case "statistics" : $icon = "glyphicon-stats"; break;
-			case "system" : $icon = "glyphicon-wrench"; break;
-			case "config" : $icon = "glyphicon-cog"; break;
-			case "info" : $icon = ""; $icontext = "<samp style='line-height:1.5;font-weight:bold;font-size:19px'>i</samp>"; break;
-			case "develop" : $icon = "glyphicon-console"; break;
+            case "dashboard" : $icon = "glyphicon-home"; break;
+            case "subscribers" : $icon = "glyphicon-user"; break;
+            case "campaigns" : $icon = "glyphicon-envelope"; break;
+            case "statistics" : $icon = "glyphicon-stats"; break;
+            case "system" : $icon = "glyphicon-wrench"; break;
+            case "config" : $icon = "glyphicon-cog"; break;
+            case "info" : $icon = ""; $icontext = "<samp style='line-height:1.5;font-weight:bold;font-size:19px'>i</samp>"; break;
+            case "develop" : $icon = "glyphicon-console"; break;
         }
+
         foreach ($categoryDetails['menulinks'] as $page) {
                 $title = $GLOBALS['I18N']->pageTitle($page);
                 $active = '';
-				if ( isset($_GET['pi']) && $page == $current_page.'&pi='.$_GET['pi']
-                	|| !$_GET['pi'] && $page == $current_page 
-                	|| $page == pageSubCategory($categoryDetails['menulinks'], $current_page) ) {
-					   $active = ' class="active"';
-                }
-                elseif (!isset($_GET['pi']) && $category == pageCategory($current_page) ){ // third level
-                    $open = ' class="active open"';
+
+                if ($_GET['pi'] !== '') {
+                    if ($page == $current_page.'&pi='.$_GET['pi']) {
+                        $active = ' class="active"';
+                    }
+                } elseif ($page == $current_page) {
+                        $active = ' class="active"';
+                } elseif (isset($GLOBALS['subcat'][$page]) && in_array($current_page, $GLOBALS['subcat'][$page])) {
+                        $active = ' class="active"';
                 }
                 $link = PageLink2($page, $title, '', true);
 
-				/* build account  menu ($accmenu) if Account section exist */
+                /* build account  menu ($accmenu) if Account section exist */
                 if ($link && $category == 'account') {
-					switch($page){
-                			case "accinfo" : $icon = "glyphicon-briefcase"; $page_title ="My account"; break;
-							case "accsettings" : $icon = "glyphicon-wrench";  $page_title ="Account settings"; break;
-							case "help" : $icon = "";$page_title = "Help"; $icontext="<samp style='line-height:1.5;font-weight:bold;font-size:19px'>?</samp>"; break;
-					}
-					if ($active == ' class="active"')  $active = ' class="open active"';
+                    switch($page){
+                            case "accinfo" : $icon = "glyphicon-briefcase"; $page_title ="My account"; break;
+                            case "accsettings" : $icon = "glyphicon-wrench";  $page_title ="Account settings"; break;
+                            case "help" : $icon = "";$page_title = "Help"; $icontext="<samp style='line-height:1.5;font-weight:bold;font-size:19px'>?</samp>"; break;
+                    }
+                    if ($active == ' class="active"')  $active = ' class="open active"';
                     $accmenu .= '<ul><li '.$active.'.><a class="level0" href="' . PageUrl2($page, '', '', true). '" title="' . $title . '"><span class="glyphicon '.$icon.'">'.$icontext.'</span>' . ucfirst($page_title) . '</a></li></ul>';
                 }
-                
+
                 /* add item to mainmenu ($thismenu) */
                  elseif ($link) {
-                	$thismenu .= '<li' . $active . '>' . $link . '</li>';
+                    $thismenu .= '<li' . $active . '>' . $link . '</li>';
                 }
-         }
+        } /* <- end foreach menulinks */
         $twohomes = array('dashboard','home');
         if ( in_array($current_page,$twohomes) && $categoryDetails['toplink'] == 'dashboard' ) { // page 'home' redirect from dashboard
                     $open = ' class=" active open"';
@@ -120,19 +112,19 @@ function _topMenu()
         if ($category != 'account' && !empty($categoryDetails['toplink'])) {
             $categoryurl = PageUrl2($categoryDetails['toplink'], '', '', true);
             if ($categoryurl) {
-            	$categoryurl = ($thismenu == "") ? $categoryurl : "#";
+                $categoryurl = ($thismenu == "") ? $categoryurl : "#";
                 $topmenu .= '<ul><li '.$open.' id="'.$category.'"><a class="level0" href="' . $categoryurl . '" title="' . $GLOBALS['I18N']->pageTitleHover($category) . '"><span class="glyphicon '.$icon.'">'.$icontext.'</span>' . ucfirst($GLOBALS['I18N']->get($category)) . '</a>' . $thismenu . '</li></ul>';
             } else {
                 $topmenu .= '<ul><li><span>' . $GLOBALS['I18N']->get($category) . $categoryurl . '</span>' . $thismenu . '</li></ul>';
             }
-        }/* <- end foreach menulinks */        
+        }
     } /* <- end foreach category */
 
-	/* add an Account  section if category exist */
-	if (!empty($accmenu)) {
-		$topmenu.='<h3 id="accmenu">'.$GLOBALS['I18N']->get('Profile and account').'</h3>'.$accmenu;
-	}
-	
+    /* add an Account  section if category exist */
+    if (!empty($accmenu)) {
+        $topmenu.='<h3 id="accmenu">'.$GLOBALS['I18N']->get('Profile and account').'</h3>'.$accmenu;
+    }
+
     $topmenu .= '</div>';
     return $topmenu;
 }


### PR DESCRIPTION
When using xdebug I noticed that the _topMenu() function was using 25% of the time to display the home page.
![webgrind](https://user-images.githubusercontent.com/3147688/78452039-e9e1c400-7680-11ea-8a04-a55e290cd92a.png)

Looking into that function showed a coding mistake and unnecessary repeated calls of some functions.

1) $_GET['pi'] is always set which means the assignment on line 92 is never executed, causing the menu sometimes not have any open section.
As an example go to Config > Admins then select an admin. The Config section of the menu is closed instead of remaining open.
Need to compare with an empty string to determine whether the current page is a plugin page.

2) Related to 1) the pageCategory() function is called for each iteration of a 2-level loop. It can be called only once to find the category of the current page.

- Lift the function call entirely outside of the loops.
- Also lift the test for whether the current menu category should be open out of the inner loop.

3) the function pageSubCategory() can be replaced by simpler code which avoids repeated calls to the function.
The function finds the subcategory for the current page. The processing then tests whether that subcategory is the same as the current menu page.
This can be replaced by simply testing whether the current page belongs to the list of pages for the current menu page, if that exists.

There are two sections of code that refer to the "Account" category - lines 97 and 120 in the original file.  I guess this applies to phplist hosted, so I'm not able to test that the changes do not break that.