### PR TITLE
Allow 'phpList community news' to be translated

### DIFF
--- a/footer_minified.inc
+++ b/footer_minified.inc
@@ -1,7 +1,7 @@
 <?php if (empty($_GET['page']) || $_GET['page'] == 'dashboard' || $_GET['page'] == 'home') { ?>
                 <div class="clear"></div>
                 <div id="newsfeed" class="menutableright block">
-                           <h3><span class="glyphicon glyphicon-bullhorn text-danger"></span> <?php print s('<a target="_blank" href="https://www.phplist.org/newslist/">phpList community news</a>'); ?></h3>
+                           <h3><span class="glyphicon glyphicon-bullhorn text-danger"></span> <?php printf('<a target="_blank" href="https://www.phplist.org/newslist/">%s</a>', s('phpList community news')); ?></h3>
                                 <?php  include 'communityfeed.php'; ?>
             </div>
 <?php } ?>


### PR DESCRIPTION
This change removes the surrounding html from the translatable text for 'phpList community news' so that the existing translations can be used. The text is already translatable due to being used in the Dressprow theme and has translations in a few languages including French
![image](https://user-images.githubusercontent.com/3147688/102345979-17b03400-3f96-11eb-8aa7-cc50c6078e92.png)

Now is translated with this theme
![image](https://user-images.githubusercontent.com/3147688/102346172-57771b80-3f96-11eb-8ddc-75f121319dc5.png)
