### PR TITLE
Avoid php notices about undefined variable and undefined index, and warning about null parameter

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -1,6 +1,4 @@
 <?php
-if ($page_title =='userclicks') $page_title = s('Click Statistics'); /* REMOVE AFTER RESOLVE MANTIS #18945 */
-
 
 /* This array is to add third level to phpList menu, adding orphan items to a menulink */
 

--- a/mainmenu.php
+++ b/mainmenu.php
@@ -3,22 +3,22 @@
 // functions for theme bootstrap
 include_once dirname(__FILE__).'/functions.php';
 
-if ($page_title == 'userclicks') $page_title = s('Click Statistics'); /* REMOVE AFTER RESOLVE MANTIS #18945 */
-
 /* fix sections not opening submenues on first click */
 $GLOBALS['pagecategories']['statistics']['toplink'] = 'statsoverview';
-$GLOBALS['pagecategories']['develop']['toplink'] = 'tests';
+if (isset($GLOBALS['pagecategories']['develop'])) {
+    $GLOBALS['pagecategories']['develop']['toplink'] = 'tests';
+}
 if ( !in_array('system', $GLOBALS['pagecategories']['system']['menulinks']) ){
-	array_push($GLOBALS['pagecategories']['system']['menulinks'],'system');
+    array_push($GLOBALS['pagecategories']['system']['menulinks'],'system');
 }
 if ( !in_array('editlist', $GLOBALS['pagecategories']['subscribers']['pages']) ){
-	array_push($GLOBALS['pagecategories']['subscribers']['pages'],'editlist');
+    array_push($GLOBALS['pagecategories']['subscribers']['pages'],'editlist');
 }
 
 /* add dashboard to top */
 if ( !isset($GLOBALS['pagecategories']['home']) && !isset($GLOBALS['pagecategories']['dashboard']) ){
-	$pcrev = array_reverse($GLOBALS['pagecategories']);
-	$pcrev['dashboard'] = array(
+    $pcrev = array_reverse($GLOBALS['pagecategories']);
+    $pcrev['dashboard'] = array(
         'toplink' => 'dashboard',
         'pages' => array('dashboard'),
         'menulinks' => array(),


### PR DESCRIPTION
When error reporting is enabled there are notices about undefined variable and index. 

![Screenshot from 2021-02-22 12-16-05](https://user-images.githubusercontent.com/3147688/108709036-1eb17080-750a-11eb-932f-48381541e743.png)
![Screenshot from 2021-02-22 12-16-17](https://user-images.githubusercontent.com/3147688/108709052-2244f780-750a-11eb-9901-054a3225b53e.png)

![Screenshot from 2021-02-22 12-18-49](https://user-images.githubusercontent.com/3147688/108709071-26711500-750a-11eb-8cf3-6a94158334f5.png)

At this stage in the processing of a page the variable $page_title has not yet been set, so the lines in mainmenu.php and functions.php that refer to it can be removed.

The undefined index is caused by setting "toplink" for the "develop" category in $pagecategories when that category does not already exist.