### PR TITLE
Avoid php 8 fatal errors when logged in as an ordinary admin

### DIFF
--- a/mainmenu.php
+++ b/mainmenu.php
@@ -4,15 +4,21 @@
 include_once dirname(__FILE__).'/functions.php';
 
 /* fix sections not opening submenues on first click */
-$GLOBALS['pagecategories']['statistics']['toplink'] = 'statsoverview';
+if (isset($GLOBALS['pagecategories']['statistics'])) {
+    $GLOBALS['pagecategories']['statistics']['toplink'] = 'statsoverview';
+}
 if (isset($GLOBALS['pagecategories']['develop'])) {
     $GLOBALS['pagecategories']['develop']['toplink'] = 'tests';
 }
-if ( !in_array('system', $GLOBALS['pagecategories']['system']['menulinks']) ){
-    array_push($GLOBALS['pagecategories']['system']['menulinks'],'system');
+if (isset($GLOBALS['pagecategories']['system'])) {
+    if ( !in_array('system', $GLOBALS['pagecategories']['system']['menulinks']) ){
+        array_push($GLOBALS['pagecategories']['system']['menulinks'],'system');
+    }
 }
-if ( !in_array('editlist', $GLOBALS['pagecategories']['subscribers']['pages']) ){
-    array_push($GLOBALS['pagecategories']['subscribers']['pages'],'editlist');
+if (isset($GLOBALS['pagecategories']['subscribers'])) {
+    if ( !in_array('editlist', $GLOBALS['pagecategories']['subscribers']['pages']) ){
+        array_push($GLOBALS['pagecategories']['subscribers']['pages'],'editlist');
+    }
 }
 
 /* add dashboard to top */


### PR DESCRIPTION
Had fatal errors when using php 8 and logged in as an ordinary admin. Due to referencing array elements that might not exist for an ordinary admin.
Part of the error log

```
[Fri Sep 10 15:13:00.115864 2021] [php:notice] [pid 12774] [client 127.0.0.1:49626] 
PHP Warning:  Undefined array key "system" in /home/duncan/www/lists_3.6.4/admin/ui/phplist-ui-bootlist/mainmenu.php on line 11
[Fri Sep 10 15:13:00.115912 2021] [php:notice] [pid 12774] [client 127.0.0.1:49626] 
PHP Warning:  Trying to access array offset on value of type null in /home/duncan/www/lists_3.6.4/admin/ui/phplist-ui-bootlist/mainmenu.php on line 11
[Fri Sep 10 15:13:00.115988 2021] [php:notice] [pid 12774] [client 127.0.0.1:49626] 
PHP Fatal error:  Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array, null given in /home/duncan/www/lists_3.6.4/admin/ui/phplist-ui-bootlist/mainmenu.php:11\nStack trace:\n#0 /home/duncan/www/lists_3.6.4/admin/ui/phplist-ui-bootlist/mainmenu.php(11): in_array()\n#1 /home/duncan/www/lists_3.6.4/admin/index.php(471): include('...')\n#2 {main}\n  thrown in /home/duncan/www/lists_3.6.4/admin/ui/phplist-ui-bootlist/mainmenu.php on line 11
```
