### PR TITLE
Avoid divide by zero error in the Last Campaign Results widget

### DIFF
--- a/pages/home.php
+++ b/pages/home.php
@@ -130,7 +130,7 @@ if ($_SESSION['logindetails']['superuser']) {
     </p>
 
     <p><span class="total"><?php echo number_format($lastcampaign['total']) ?></span> Messages sent on <span class="total"><?php echo $lastcampaign['sent'] ?></span>.</p>
-    <p><span class="total"><?php echo number_format($lastcampaign['views']) ?> </span> Viewed (<span class="total"><?php echo sprintf('%0.2f', ($lastcampaign['views'] / ($lastcampaign['total'] - $lastcampaign['bounced']) * 100)) ?>%</span>), and <span class="total"><?php echo $lastcampaign['bounced'] ?></span> bounced (<span class="total"><?php echo sprintf('%0.2f', ($lastcampaign['bounced'] / $lastcampaign['total'] * 100)) ?>%</span>).</p>
+    <p><span class="total"><?php echo number_format($lastcampaign['views']) ?> </span> Viewed (<span class="total"><?php echo sprintf('%0.2f', ($lastcampaign['views'] / max(1, $lastcampaign['total'] - $lastcampaign['bounced']) * 100)) ?>%</span>), and <span class="total"><?php echo $lastcampaign['bounced'] ?></span> bounced (<span class="total"><?php echo sprintf('%0.2f', ($lastcampaign['bounced'] / max(1, $lastcampaign['total']) * 100)) ?>%</span>).</p>
 
     <?php
 } ?>


### PR DESCRIPTION
Avoid divide by zero error in the Last Campaign Results widget when 0 emails were sent or all emails bounced.
Use 1 instead of 0 as the divisor in the calculation of the percentages for the Last Campaign widget.
From the error log

```
[Tue Sep 14 12:04:20.790818 2021] [php:notice] [pid 1020] [client 127.0.0.1:51312]
PHP Fatal error:  Uncaught DivisionByZeroError: Division by zero in /home/duncan/www/lists_3.6.4/admin/ui/phplist-ui-bootlist/pages/home.php:133\nStack trace:\n#0 /home/duncan/www/lists_3.6.4/admin/index.php(754): include()\n#1 {main}\n  thrown in /home/duncan/www/lists_3.6.4/admin/ui/phplist-ui-bootlist/pages/home.php on line 133, referer: http://strontian/lists/admin/
```

After the change
![image](https://user-images.githubusercontent.com/3147688/133250769-16776387-8491-46f0-9beb-b2b9fe3bdfde.png)